### PR TITLE
CCI PR 24857 Suggestions for Review

### DIFF
--- a/recipes/reflect-cpp/all/conanfile.py
+++ b/recipes/reflect-cpp/all/conanfile.py
@@ -82,6 +82,10 @@ class ReflectCppConan(ConanFile):
     def package(self):
         copy(self, pattern="LICENSE*", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         copy(
+
+
+
+
             self,
             pattern="*.hpp",
             dst=os.path.join(self.package_folder, "include"),

--- a/recipes/reflect-cpp/all/conanfile.py
+++ b/recipes/reflect-cpp/all/conanfile.py
@@ -82,10 +82,6 @@ class ReflectCppConan(ConanFile):
     def package(self):
         copy(self, pattern="LICENSE*", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         copy(
-
-
-
-
             self,
             pattern="*.hpp",
             dst=os.path.join(self.package_folder, "include"),

--- a/recipes/reflectcpp/all/conanfile.py
+++ b/recipes/reflectcpp/all/conanfile.py
@@ -1,9 +1,13 @@
 from conan import ConanFile
-from conan.tools.files import get, copy
+from conan.tools.files import get, copy, rmdir
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.build import check_min_cppstd
+from conan.tools.scm import Version
+from conan.errors import ConanInvalidConfiguration
 import os
 
-required_conan_version = ">=1.51.1"
+required_conan_version = ">=1.54"
 
 
 class ReflectCppConan(ConanFile):
@@ -32,7 +36,6 @@ class ReflectCppConan(ConanFile):
         "fPIC": [True, False],
         "with_cbor": [True, False],
         "with_flatbuffers": [True, False],
-        "with_json": [True, False],
         "with_msgpack": [True, False],
         "with_toml": [True, False],
         "with_xml": [True, False],
@@ -43,14 +46,11 @@ class ReflectCppConan(ConanFile):
         "fPIC": True,
         "with_cbor": False,
         "with_flatbuffers": False,
-        "with_json": True,
         "with_msgpack": False,
         "with_toml": False,
         "with_xml": False,
         "with_yaml": False,
     }
-    src_folder = "src"
-    build_requires = "cmake/3.30.1"
 
     @property
     def _min_cppstd(self):
@@ -61,8 +61,8 @@ class ReflectCppConan(ConanFile):
         return {
             "Visual Studio": "17",
             "msvc": "193",
-            "gcc": "11.4",
-            "clang": "16",
+            "gcc": "11",
+            "clang": "13",
             "apple-clang": "15",
         }
 
@@ -74,32 +74,13 @@ class ReflectCppConan(ConanFile):
         if self.options.shared:
             self.options.rm_safe("fPIC")
 
-    def layout(self):
-        cmake_layout(self)
-
-    def generate(self):
-        deps = CMakeDeps(self)
-        deps.generate()
-        tc = CMakeToolchain(self)
-        tc.generate()
-
-    def build(self):
-        cmake = CMake(self)
-        cmake.configure(cli_args=["-DREFLECTCPP_USE_BUNDLED_DEPENDENCIES=OFF"])
-        cmake.build()
-
-    def package(self):
-        cmake = CMake(self)
-        cmake.install()
-
     def requirements(self):
         self.requires("ctre/3.9.0", transitive_headers=True)
+        self.requires("yyjson/0.10.0", transitive_headers=True)
         if self.options.with_cbor:
             self.requires("tinycbor/0.6.0", transitive_headers=True)
         if self.options.with_flatbuffers:
-            self.requires("flatbuffers/23.5.26", transitive_headers=True)
-        if self.options.with_json:
-            self.requires("yyjson/0.8.0", transitive_headers=True)
+            self.requires("flatbuffers/24.3.25", transitive_headers=True)
         if self.options.with_msgpack:
             self.requires("msgpack-c/6.0.0", transitive_headers=True)
         if self.options.with_toml:
@@ -109,8 +90,51 @@ class ReflectCppConan(ConanFile):
         if self.options.with_yaml:
             self.requires("yaml-cpp/0.8.0", transitive_headers=True)
 
+    def build_requirements(self):
+        self.tool_requires("cmake/[>=3.23 <4]")
+
+    def validate(self):
+        if self.settings.get_safe("compiler.cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.")
+
+    def layout(self):
+        cmake_layout(self, src_folder="src")
+
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
 
+    def generate(self):
+        env = VirtualBuildEnv(self)
+        env.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.cache_variables["REFLECTCPP_BUILD_SHARED"] = self.options.shared
+        tc.cache_variables["REFLECTCPP_USE_BUNDLED_DEPENDENCIES"] = False
+        tc.cache_variables["REFLECTCPP_USE_VCPKG"] = False
+        tc.cache_variables["REFLECTCPP_CBOR"] = self.options.with_cbor
+        tc.cache_variables["REFLECTCPP_FLEXBUFFERS"] = self.options.with_flatbuffers
+        tc.cache_variables["REFLECTCPP_MSGPACK"] = self.options.with_msgpack
+        tc.cache_variables["REFLECTCPP_TOML"] = self.options.with_toml
+        tc.cache_variables["REFLECTCPP_XML"] = self.options.with_xml
+        tc.cache_variables["REFLECTCPP_YAML"] = self.options.with_yaml
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        cmake = CMake(self)
+        cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
     def package_info(self):
         self.cpp_info.libs = ["reflectcpp"]
+        if self.settings.os in ["FreeBSD", "Linux"]:
+            self.cpp_info.system_libs = ["m"]

--- a/recipes/reflectcpp/all/test_package/CMakeLists.txt
+++ b/recipes/reflectcpp/all/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15)
 project(test_package LANGUAGES CXX)
 
 find_package(reflectcpp REQUIRED CONFIG)
@@ -6,7 +6,3 @@ find_package(reflectcpp REQUIRED CONFIG)
 add_executable(${PROJECT_NAME} test_package.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE reflectcpp::reflectcpp)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
-
-if(CONAN_TEST_WITH_MSGPACK)
-  target_compile_definitions(${PROJECT_NAME} PRIVATE CONAN_TEST_WITH_MSGPACK)
-endif()

--- a/recipes/reflectcpp/all/test_package/conanfile.py
+++ b/recipes/reflectcpp/all/test_package/conanfile.py
@@ -14,11 +14,9 @@ class TestPackageConan(ConanFile):
 
     def layout(self):
         cmake_layout(self)
-        
+
     def generate(self):
         tc = CMakeToolchain(self)
-        if self.dependencies[self.tested_reference_str].options.with_msgpack:
-            tc.cache_variables["CONAN_TEST_WITH_MSGPACK"] = True
         tc.generate()
 
     def build(self):

--- a/recipes/reflectcpp/all/test_package/test_package.cpp
+++ b/recipes/reflectcpp/all/test_package/test_package.cpp
@@ -1,29 +1,16 @@
+#include <cstdlib>
 #include <iostream>
-#include <rfl.hpp>
 #include <string>
 
-#if defined(CONAN_TEST_WITH_MSGPACK)
-#include <rfl/msgpack.hpp>
-#endif
+#include "rfl.hpp"
+#include "rfl/Generic.hpp"
+#include "rfl/json.hpp"
 
-struct TestStruct {
-    int x;
-    std::string name;
-};
 
 int main(void) {
-    for (const auto& f : rfl::fields<TestStruct>()) {
-        (void)f.name();
-        (void)f.type();
-    }
-
-#if defined(CONAN_TEST_WITH_MSGPACK)
-    const auto test = TestStruct{.x = 15, .name = "test_package"};
-    std::cout << "msgpack test: ";
-    rfl::msgpack::write(test, std::cout) << std::endl;
-#endif
-
-    std::cout << "reflectcpp test successful\n";
-
-    return 0;
+    auto person = rfl::Generic::Object();
+    person["first_name"] = "John";
+    person["last_name"] = "Doe";
+    rfl::json::write(person, std::cout) << std::endl;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Instead doing repetitive reviews for the PR [24857](https://github.com/conan-io/conan-center-index/pull/24857), I preferred to send this patch with my suggestions instead:

- Json is mandatory requirement, do not need an option: https://github.com/getml/reflect-cpp/blob/v0.14.0/CMakeLists.txt#L83
- Use CMakeToolchain.cache_variables instead of cli args
- Use the latest version available in Conan Center for each dependency
- Raise invalid configuration in case cppstd or compilers do not fit
- Follow options vs cmake definitions
- Fix shared option definition to REFLECTCPP_BUILD_SHARED
- Use version range to install CMake as tool requires
- Use cmake_layout to define the source folder
- Add VirtualBuildEnv to load cmake environment
- Copy license file to package folder
- Remove upstream cmake config file from package. Use CMakeDeps instead.
- Add libm as system requirement. Used by src/yyjson.c:10:#include <math.h>
- Simplify test package to consume only mandatory components
- Validated on Linux + GCC13